### PR TITLE
Fix crash when importing and library isn’t linked

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1,13 +1,10 @@
 import React from "react";
 import { NativeEventEmitter, NativeModules, requireNativeComponent, View } from "react-native";
 function getHelp() {
-    try {
-        const loaded = requireNativeComponent("RNTHelpshift");
-        return loaded;
+    if ("RNTHelpshift" in NativeModules.UIManager) {
+        return requireNativeComponent("RNTHelpshift");
     }
-    catch (_a) {
-        return View;
-    }
+    return View;
 }
 const RNTHelpshift = getHelp();
 const { RNHelpshift } = NativeModules;

--- a/index.tsx
+++ b/index.tsx
@@ -30,12 +30,10 @@ interface HelpshiftProps {
 }
 
 function getHelp() {
-  try {
-    const loaded = requireNativeComponent("RNTHelpshift");
-    return loaded;
-  } catch {
-    return View;
+  if ("RNTHelpshift" in NativeModules.UIManager) {
+    return requireNativeComponent("RNTHelpshift");
   }
+  return View;
 }
 
 const RNTHelpshift = getHelp();


### PR DESCRIPTION
I had an extra guard protecting me so the old solution didn't actually work. This has since been tested and should work as expected.